### PR TITLE
Handle missing article links when parsing feed

### DIFF
--- a/fetch-rss.js
+++ b/fetch-rss.js
@@ -81,6 +81,11 @@ async function fetchAndProcessFeed() {
       const itemArticleContent = item['content:encoded'];
       const itemArticleLink = extractHrefFromContent(itemArticleContent);
 
+      if (!itemArticleLink) {
+        console.warn(`Missing article link for ${item.title}. Skipping.`);
+        continue;
+      }
+
       if (skipSitesMatches.some(site => itemArticleLink.includes(site))) {
         continue;
       }


### PR DESCRIPTION
## Summary
- skip feed items that do not include an article link to avoid runtime errors when filtering

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9c2c3949c8326ae06796ed085729c