### PR TITLE
Handle Eurogamer parsing failures without crashing

### DIFF
--- a/fetch-eurogamer-rss.js
+++ b/fetch-eurogamer-rss.js
@@ -72,11 +72,12 @@ async function fetchAndProcessFeed() {
           author: [{ name: item.author || item.creator || 'Unknown' }],
         });
       } else {
-        console.warn(`Failed to parse content for ${itemArticleContent || itemArticleLink}`);
+        const fallbackIdentifier = itemArticleLink || item.link || item.title || 'Unknown item';
+        console.warn(`Failed to parse content for ${fallbackIdentifier}`);
         if (!existingArticleIds.has(item.link)) {
           hasNewArticles = true;
         }
-        feed.addItem(item)
+        feed.addItem(item);
       }
     } catch (err) {
       console.error(`Error processing ${item}:`, err);


### PR DESCRIPTION
## Summary
- avoid referencing an undefined variable when Readability fails on Eurogamer articles
- log the best available identifier for debugging and keep processing the feed

## Testing
- node fetch-eurogamer-rss.js *(fails: ENETUNREACH in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9c815856883269a27ab1231ab24f7